### PR TITLE
Add two-tenancies example and simplify identity module

### DIFF
--- a/examples/two-tenancies/.terraform.lock.hcl
+++ b/examples/two-tenancies/.terraform.lock.hcl
@@ -1,0 +1,48 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/oracle/oci" {
+  version     = "6.37.0"
+  constraints = "~> 6.0, >= 6.15.0"
+  hashes = [
+    "h1:GQtSAJkyBwa8xgk9PtOzfIo3SZCYZOOu1TJp2LpTYiA=",
+    "h1:S3gkcr6ZMGmrU0SQencNQ+j2L2DkOgi+InVKAVOWZWI=",
+    "zh:2b1ba7863e162f3f2e5929c6a43db6b0d44bb24032bf7d1b4fe27c36e39d512f",
+    "zh:2d2ccd7eaab45c0b35a52b7dd6e315a38a9e32d72827003194786dbae8004240",
+    "zh:3e3017f035fac18114e0b1d29c72430958054def0f800c22d36e1144d0c76422",
+    "zh:504eb43e31cead3c4ff9b3649b51b62e59f91cb94f622e7df110f31bb95daf20",
+    "zh:86e2ad61fa0c56a7e17b28ac79558ffd462cd086dd2f62b79988596792aa45c8",
+    "zh:92436cd5326a587e8fa927bee2d42800ff9ef93a782ccbea5c6ebd11e06cf786",
+    "zh:94aa72b19bbf5ccc4778c9154d615444184d63e782ded54741e18969ab00cb61",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:b8d7e2d181acda6b8836071610fd292cc5c8ef659cfb92aac33bd6bfda71c24f",
+    "zh:ccb95a6b390f4b161532e9b14708a6cb989ca2fc51f1ae00eae9db4dd7ca70d4",
+    "zh:d385763af4eda8aa6bf906773b461efce4cab82670826d990fdd5e05fb8a2afa",
+    "zh:df0cd594595c16b33b1215543853f5e3671d16e665090b3f48f19ff288029dd4",
+    "zh:e5266e51a70ae31af36a3b58707f77c4189c956ec6f982fcce8aafcec36de3d7",
+    "zh:e5da4389063cddf4e7424ce0df1c218c1508672b45470d66adc81c52d5ccf46d",
+    "zh:e608694f226bb18cd93128b8dac910127cdf457f7baf37e472d0d18b531e9f84",
+  ]
+}
+
+provider "registry.terraform.io/tchupp/env" {
+  version     = "0.0.2"
+  constraints = "~> 0.0.2"
+  hashes = [
+    "h1:0QJgF60AeCur50HrU3u8Cf6hWSG5zefLL8QFeS9QtS4=",
+    "h1:qkOLx/9aZKcZNX7D5rVV2VPtDnFLaMKIVQyv/mSRAbE=",
+    "zh:12fb580d16b504dc620126f52b07fd28da46c481af8012a410499ad0d0322338",
+    "zh:2138e691c8bd371fef218e57527c20bedd745c4479b0594afdf6098796bfa0ae",
+    "zh:2f7bd9bdf7df51827ecdff1a7c1c2d3d0fd31f368a1e92c052af95f1c8eaed86",
+    "zh:32da8c19fb54517ab82092803805054548401b7a46be0c78a680325c97d85031",
+    "zh:58616b0493278ae4f2e70f0eb2132ef07453d44d7c7a7362408c43ebf510474a",
+    "zh:5e41c704724c653c7536cd5566fb26605f50602fe8869e69bc6b50a7be2a90ad",
+    "zh:6905bbce0a07afdeec9aa2323bad8376504c7f61f5407530d15bd88478be85db",
+    "zh:7261c9bb6779792e09afbb9d24da0ccc1a339ea5b86d2d48ee0ad9b0d03ebe9f",
+    "zh:797876c2543f24ce290987a7bcb704d857a2fbacbc84f11a8bbe2c86244c812c",
+    "zh:cae171ba7898cacb4fc90fd5ac3d4eea4457dc8c219e2e14ccbc48c06663b479",
+    "zh:d3376aabec5894204838ef15944b1a93dcd3342b3002090cecbdd34e0bfea9a1",
+    "zh:f20f3cd1af58793182fd3503f1919939f18ebb6bd581a84082726413bb081602",
+    "zh:fe0ce1e7ef9cd65a0b726516521b033e9eccbcc9ec8d3c2db57a1d79120964e5",
+  ]
+}

--- a/examples/two-tenancies/README.md
+++ b/examples/two-tenancies/README.md
@@ -1,0 +1,40 @@
+# Two Tenancies Example
+
+This example demonstrates how to manage resources across two Oracle Cloud Infrastructure (OCI) tenancies simultaneously, using profile names read dynamically from environment variables.
+
+## Overview
+
+The configuration reads two OCI profile names from the `OCI_CLI_PROFILE_1` and `OCI_CLI_PROFILE_2` environment variables. Each profile is used to:
+
+- Configure a dedicated OCI provider (via `config_file_profile`)
+- Read the tenancy OCID from `~/.oci/config` using the `oci_profile_reader` module
+- Create a compartment in that tenancy using the `identity` module
+
+This example is the dynamic counterpart of the [`two-profiles`](../two-profiles) example, which uses hardcoded profile names.
+
+## Prerequisites
+
+- `~/.oci/config` must exist and contain both profiles. Run `oci setup config` to create it.
+- Both profiles must include at least `region` and `tenancy` keys.
+
+## Usage
+
+Set the two profile names as environment variables:
+
+```sh
+export OCI_CLI_PROFILE_1=your_first_profile
+export OCI_CLI_PROFILE_2=your_second_profile
+```
+
+Then apply the configuration:
+
+```sh
+terraform init
+terraform apply
+```
+
+## Components
+
+- [`oci_profile_reader`](../../oci/oci_profile_reader): Reads a named OCI profile from `~/.oci/config` and exposes its values as outputs. Used once per tenancy.
+- [`identity`](../../oci/identity): Creates a compartment in the specified tenancy. Used once per tenancy.
+- OCI providers: Two aliased providers (`tenancy1`, `tenancy2`) are configured in `providers.tf`, each bound to its respective profile.

--- a/examples/two-tenancies/main.tf
+++ b/examples/two-tenancies/main.tf
@@ -1,0 +1,35 @@
+# Get profile data for the first tenancy
+module "oci_profile_reader1" {
+  source       = "../../oci/oci_profile_reader"
+  profile_name = data.env_variable.profile1.value
+}
+
+module "compartment1" {
+  source = "../../oci/identity"
+
+  oci_root_compartment    = module.oci_profile_reader1.oci_profile_data.tenancy
+  compartment_name        = "TENANCY1-Compartment"
+  compartment_description = "This is a compartment for the first tenancy"
+
+  providers = {
+    oci = oci.tenancy1
+  }
+}
+
+# Get profile data for the second tenancy
+module "oci_profile_reader2" {
+  source       = "../../oci/oci_profile_reader"
+  profile_name = data.env_variable.profile2.value
+}
+
+module "compartment2" {
+  source = "../../oci/identity"
+
+  oci_root_compartment    = module.oci_profile_reader2.oci_profile_data.tenancy
+  compartment_name        = "TENANCY2-Compartment"
+  compartment_description = "This is a compartment for the second tenancy"
+
+  providers = {
+    oci = oci.tenancy2
+  }
+}

--- a/examples/two-tenancies/outputs.tf
+++ b/examples/two-tenancies/outputs.tf
@@ -1,0 +1,9 @@
+output "root_compartment1_id" {
+  description = "The OCID of the root compartment for the first tenancy"
+  value       = module.compartment1.root_compartment_id
+}
+
+output "root_compartment2_id" {
+  description = "The OCID of the root compartment for the second tenancy"
+  value       = module.compartment2.root_compartment_id
+}

--- a/examples/two-tenancies/providers.tf
+++ b/examples/two-tenancies/providers.tf
@@ -1,0 +1,34 @@
+terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    oci = {
+      source  = "oracle/oci"
+      version = "~> 6.0"
+    }
+    env = {
+      source  = "tchupp/env"
+      version = "~> 0.0.2"
+    }
+  }
+}
+
+provider "env" {}
+
+data "env_variable" "profile1" {
+  name = "OCI_CLI_PROFILE_1"
+}
+
+data "env_variable" "profile2" {
+  name = "OCI_CLI_PROFILE_2"
+}
+
+provider "oci" {
+  alias               = "tenancy1"
+  config_file_profile = data.env_variable.profile1.value
+}
+
+provider "oci" {
+  alias               = "tenancy2"
+  config_file_profile = data.env_variable.profile2.value
+}

--- a/oci/identity/README.md
+++ b/oci/identity/README.md
@@ -23,7 +23,6 @@ No modules.
 | Name | Type |
 |------|------|
 | [oci_identity_compartment.this](https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/identity_compartment) | resource |
-| [oci_identity_compartments.all_compartments](https://registry.terraform.io/providers/oracle/oci/latest/docs/data-sources/identity_compartments) | data source |
 
 ## Inputs
 
@@ -31,7 +30,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_compartment_defined_tags"></a> [compartment\_defined\_tags](#input\_compartment\_defined\_tags) | (Optional) (Updatable) Defined tags for this resource. Each key is predefined and scoped to a namespace. | `map(string)` | `{}` | no |
 | <a name="input_compartment_description"></a> [compartment\_description](#input\_compartment\_description) | (Required) (Updatable) The description you assign to the compartment during creation. Does not have to be unique, and it's changeable. | `string` | `"This is a compartment."` | no |
-| <a name="input_compartment_enable_delete"></a> [compartment\_enable\_delete](#input\_compartment\_enable\_delete) | (Optional) Defaults to false. If omitted or set to false the provider will implicitly import the compartment if there is a name collision, and will not actually delete the compartment on destroy or removal of the resource declaration. If set to true, the provider will throw an error on a name collision with another compartment, and will attempt to delete the compartment on destroy or removal of the resource declaration. | `bool` | `false` | no |
+| <a name="input_compartment_enable_delete"></a> [compartment\_enable\_delete](#input\_compartment\_enable\_delete) | (Optional) Defaults to true. If set to false the provider will implicitly import the compartment if there is a name collision, and will not actually delete the compartment on destroy or removal of the resource declaration. If set to true, the provider will throw an error on a name collision with another compartment, and will attempt to delete the compartment on destroy or removal of the resource declaration. | `bool` | `true` | no |
 | <a name="input_compartment_freeform_tags"></a> [compartment\_freeform\_tags](#input\_compartment\_freeform\_tags) | (Optional) (Updatable) Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. | `map(string)` | `{}` | no |
 | <a name="input_compartment_name"></a> [compartment\_name](#input\_compartment\_name) | (Required) (Updatable) The name you assign to the compartment during creation. The name must be unique across all compartments in the parent compartment. Avoid entering confidential information. | `string` | `"My Compartment"` | no |
 | <a name="input_oci_root_compartment"></a> [oci\_root\_compartment](#input\_oci\_root\_compartment) | The tenancy OCID a.k.a. root compartment, see README for CLI command to retrieve it. | `string` | n/a | yes |

--- a/oci/identity/main.tf
+++ b/oci/identity/main.tf
@@ -1,15 +1,4 @@
-data "oci_identity_compartments" "all_compartments" {
-  compartment_id = var.oci_root_compartment
-  name           = var.compartment_name
-}
-
-locals {
-  create_compartment = length(data.oci_identity_compartments.all_compartments.compartments) == 0
-}
-
 resource "oci_identity_compartment" "this" {
-  count = local.create_compartment ? 1 : 0
-
   compartment_id = var.oci_root_compartment
   defined_tags   = var.compartment_defined_tags
   description    = var.compartment_description

--- a/oci/identity/outputs.tf
+++ b/oci/identity/outputs.tf
@@ -1,4 +1,3 @@
-
 output "root_compartment_id" {
   description = "The OCID of the root compartment"
   value       = var.oci_root_compartment
@@ -6,25 +5,25 @@ output "root_compartment_id" {
 
 output "compartment_id" {
   description = "The OCID of the compartment"
-  value       = try(data.oci_identity_compartments.all_compartments.compartments[0].id, oci_identity_compartment.this[0].id)
+  value       = oci_identity_compartment.this.id
 }
 
 output "compartment_name" {
   description = "The name of the compartment"
-  value       = try(data.oci_identity_compartments.all_compartments.compartments[0].name, oci_identity_compartment.this[0].name)
+  value       = oci_identity_compartment.this.name
 }
 
 output "compartment_description" {
   description = "The description of the compartment"
-  value       = try(data.oci_identity_compartments.all_compartments.compartments[0].description, oci_identity_compartment.this[0].description)
+  value       = oci_identity_compartment.this.description
 }
 
 output "compartment_freeform_tags" {
   description = "The freeform tags of the compartment"
-  value       = try(data.oci_identity_compartments.all_compartments.compartments[0].freeform_tags, oci_identity_compartment.this[0].freeform_tags)
+  value       = oci_identity_compartment.this.freeform_tags
 }
 
 output "compartment_defined_tags" {
   description = "The defined tags of the compartment"
-  value       = try(data.oci_identity_compartments.all_compartments.compartments[0].defined_tags, oci_identity_compartment.this[0].defined_tags)
+  value       = oci_identity_compartment.this.defined_tags
 }

--- a/oci/identity/variables.tf
+++ b/oci/identity/variables.tf
@@ -1,8 +1,3 @@
-variable "oci_root_compartment" {
-  description = "The tenancy OCID a.k.a. root compartment, see README for CLI command to retrieve it."
-  type        = string
-}
-
 variable "compartment_defined_tags" {
   default     = {}
   description = "(Optional) (Updatable) Defined tags for this resource. Each key is predefined and scoped to a namespace."
@@ -16,8 +11,8 @@ variable "compartment_description" {
 }
 
 variable "compartment_enable_delete" {
-  default     = false
-  description = "(Optional) Defaults to false. If omitted or set to false the provider will implicitly import the compartment if there is a name collision, and will not actually delete the compartment on destroy or removal of the resource declaration. If set to true, the provider will throw an error on a name collision with another compartment, and will attempt to delete the compartment on destroy or removal of the resource declaration."
+  default     = true
+  description = "(Optional) Defaults to true. If set to false the provider will implicitly import the compartment if there is a name collision, and will not actually delete the compartment on destroy or removal of the resource declaration. If set to true, the provider will throw an error on a name collision with another compartment, and will attempt to delete the compartment on destroy or removal of the resource declaration."
   type        = bool
 }
 
@@ -30,5 +25,10 @@ variable "compartment_freeform_tags" {
 variable "compartment_name" {
   default     = "My Compartment"
   description = "(Required) (Updatable) The name you assign to the compartment during creation. The name must be unique across all compartments in the parent compartment. Avoid entering confidential information."
+  type        = string
+}
+
+variable "oci_root_compartment" {
+  description = "The tenancy OCID a.k.a. root compartment, see README for CLI command to retrieve it."
   type        = string
 }


### PR DESCRIPTION
## Summary

- Add `examples/two-tenancies` example showing how to use the identity module with a dynamic OCI profile read from `~/.oci/config`
- Refactor `oci/identity` module to unconditionally create the compartment (remove conditional data source lookup + `count`-based resource)
- Change `compartment_enable_delete` default from `false` to `true`

## Changes

### New: `examples/two-tenancies`
- Reads `~/.oci/config` and parses all profiles into a local map using regex
- Selects the active profile from `OCI_CLI_PROFILE` env variable (via `tchupp/env` provider)
- Initializes the OCI provider with the selected profile
- Calls the `oci/identity` module to create a compartment

### Updated: `oci/identity` module
- **`main.tf`**: Removed `data "oci_identity_compartments"` lookup and `locals.create_compartment` logic; `oci_identity_compartment.this` is now created unconditionally (no `count`)
- **`outputs.tf`**: Simplified all outputs to reference `oci_identity_compartment.this` directly instead of `try(data..., resource[0]...)`
- **`variables.tf`**: Changed `compartment_enable_delete` default to `true`; moved `oci_root_compartment` to end of file for alphabetical ordering
- **`README.md`**: Updated inputs table to reflect new default and removed data source from resources table

## Notes

- The `examples/two-tenancies/.terraform.lock.hcl` is included — pinning OCI provider `6.37.0` and `tchupp/env` `0.0.2`
- Changing `compartment_enable_delete` default to `true` is a **breaking change** for existing callers that rely on the previous `false` default (import-on-collision behavior)