### PR TITLE
fix(budget): add input validations and fix alert display_name default

### DIFF
--- a/oci/budget/README.md
+++ b/oci/budget/README.md
@@ -63,7 +63,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_alert_defined_tags"></a> [alert\_defined\_tags](#input\_alert\_defined\_tags) | Defined tags for the alert rule. | `map(string)` | `{}` | no |
 | <a name="input_alert_description"></a> [alert\_description](#input\_alert\_description) | Description for alert rule. | `string` | `""` | no |
-| <a name="input_alert_display_name"></a> [alert\_display\_name](#input\_alert\_display\_name) | Display name of the alert rule. | `string` | `"Alert on $0.01 forecast spend"` | no |
+| <a name="input_alert_display_name"></a> [alert\_display\_name](#input\_alert\_display\_name) | Display name of the alert rule. Only a-zA-Z0-9.-\_ characters are allowed. | `string` | `"Alert_on_0.01_forecast_spend"` | no |
 | <a name="input_alert_freeform_tags"></a> [alert\_freeform\_tags](#input\_alert\_freeform\_tags) | Free-form tags for the alert rule. | `map(string)` | `{}` | no |
 | <a name="input_alert_message"></a> [alert\_message](#input\_alert\_message) | Custom message for alert notification. | `string` | `""` | no |
 | <a name="input_alert_recipients"></a> [alert\_recipients](#input\_alert\_recipients) | The delimited list of email addresses to receive the alert when it triggers. Delimiter characters can be a comma, space, TAB, or semicolon. | `string` | `""` | no |
@@ -71,16 +71,16 @@ No modules.
 | <a name="input_alert_threshold_type"></a> [alert\_threshold\_type](#input\_alert\_threshold\_type) | Type of threshold. | `string` | `"PERCENTAGE"` | no |
 | <a name="input_alert_type"></a> [alert\_type](#input\_alert\_type) | Type of alert rule. | `string` | `"FORECAST"` | no |
 | <a name="input_budget_amount"></a> [budget\_amount](#input\_budget\_amount) | (Required) (Updatable) The amount of the budget expressed as a whole number in the currency of the customer's rate card. | `number` | `1` | no |
-| <a name="input_budget_compartment_id"></a> [budget\_compartment\_id](#input\_budget\_compartment\_id) | Compartment OCID for the budget. | `string` | n/a | yes |
+| <a name="input_budget_compartment_id"></a> [budget\_compartment\_id](#input\_budget\_compartment\_id) | Compartment OCID for the budget. Must be the root tenancy OCID. | `string` | n/a | yes |
 | <a name="input_budget_defined_tags"></a> [budget\_defined\_tags](#input\_budget\_defined\_tags) | Defined tags for the budget. | `map(string)` | `{}` | no |
 | <a name="input_budget_description"></a> [budget\_description](#input\_budget\_description) | Description of the budget. | `string` | `""` | no |
-| <a name="input_budget_display_name"></a> [budget\_display\_name](#input\_budget\_display\_name) | Display name for the budget. | `string` | `"MonthlyBudget"` | no |
+| <a name="input_budget_display_name"></a> [budget\_display\_name](#input\_budget\_display\_name) | Display name for the budget. Only a-zA-Z0-9.-\_ characters are allowed. | `string` | `"MonthlyBudget"` | no |
 | <a name="input_budget_freeform_tags"></a> [budget\_freeform\_tags](#input\_budget\_freeform\_tags) | Free-form tags for the budget. | `map(string)` | `{}` | no |
 | <a name="input_budget_processing_period_start_offset"></a> [budget\_processing\_period\_start\_offset](#input\_budget\_processing\_period\_start\_offset) | (Optional) (Updatable) The number of days offset from the first day of the month, at which the budget processing period starts. In months that have fewer days than this value, processing will begin on the last day of that month. For example, for a value of 12, processing starts every month on the 12th at midnight. | `number` | `1` | no |
 | <a name="input_budget_processing_period_type"></a> [budget\_processing\_period\_type](#input\_budget\_processing\_period\_type) | Processing period type (INVOICE or MONTH). | `string` | `"MONTH"` | no |
 | <a name="input_budget_reset_period"></a> [budget\_reset\_period](#input\_budget\_reset\_period) | (Required) (Updatable) The reset period for the budget. Valid value is MONTHLY. | `string` | `"MONTHLY"` | no |
 | <a name="input_budget_target_type"></a> [budget\_target\_type](#input\_budget\_target\_type) | The type of target for the budget. | `string` | `"COMPARTMENT"` | no |
-| <a name="input_budget_targets"></a> [budget\_targets](#input\_budget\_targets) | (Optional) The list of targets on which the budget is applied. If targetType is 'COMPARTMENT', the targets contain the list of compartment OCIDs. If targetType is 'TAG', the targets contain the list of cost tracking tag identifiers in the form of '{tagNamespace}.{tagKey}.{tagValue}'. Curerntly, the array should contain exactly one item. | `list(string)` | n/a | yes |
+| <a name="input_budget_targets"></a> [budget\_targets](#input\_budget\_targets) | (Optional) The list of targets on which the budget is applied. If targetType is 'COMPARTMENT', the targets contain the list of compartment OCIDs. If targetType is 'TAG', the targets contain the list of cost tracking tag identifiers in the form of '{tagNamespace}.{tagKey}.{tagValue}'. Currently, the array should contain exactly one item. | `list(string)` | n/a | yes |
 
 ## Outputs
 

--- a/oci/budget/variables.tf
+++ b/oci/budget/variables.tf
@@ -11,9 +11,13 @@ variable "alert_description" {
 }
 
 variable "alert_display_name" {
-  default     = "Alert on $0.01 forecast spend"
-  description = "Display name of the alert rule."
+  default     = "Alert_on_0.01_forecast_spend"
+  description = "Display name of the alert rule. Only a-zA-Z0-9.-_ characters are allowed."
   type        = string
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9._-]+$", var.alert_display_name))
+    error_message = "alert_display_name may contain only the characters a-zA-Z0-9.-_"
+  }
 }
 
 variable "alert_freeform_tags" {
@@ -38,6 +42,10 @@ variable "alert_threshold" {
   default     = 1
   description = "Threshold value for triggering the alert."
   type        = number
+  validation {
+    condition     = var.alert_threshold > 0
+    error_message = "alert_threshold must be greater than 0."
+  }
 }
 
 variable "alert_threshold_type" {
@@ -71,8 +79,12 @@ variable "budget_amount" {
 }
 
 variable "budget_compartment_id" {
-  description = "Compartment OCID for the budget."
+  description = "Compartment OCID for the budget. Must be the root tenancy OCID."
   type        = string
+  validation {
+    condition     = can(regex("^ocid1\\.[a-z]+\\.[a-z][a-z0-9-]*\\.[a-z0-9-]*\\.[a-z0-9]+$", var.budget_compartment_id))
+    error_message = "budget_compartment_id must be a valid OCI OCID (e.g. ocid1.tenancy.oc1..aaaaaa...)."
+  }
 }
 
 variable "budget_defined_tags" {
@@ -89,8 +101,12 @@ variable "budget_description" {
 
 variable "budget_display_name" {
   default     = "MonthlyBudget"
-  description = "Display name for the budget."
+  description = "Display name for the budget. Only a-zA-Z0-9.-_ characters are allowed."
   type        = string
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9._-]+$", var.budget_display_name))
+    error_message = "budget_display_name may contain only the characters a-zA-Z0-9.-_"
+  }
 }
 
 variable "budget_freeform_tags" {
@@ -103,6 +119,10 @@ variable "budget_processing_period_start_offset" {
   default     = 1
   description = "(Optional) (Updatable) The number of days offset from the first day of the month, at which the budget processing period starts. In months that have fewer days than this value, processing will begin on the last day of that month. For example, for a value of 12, processing starts every month on the 12th at midnight."
   type        = number
+  validation {
+    condition     = var.budget_processing_period_start_offset >= 1 && var.budget_processing_period_start_offset <= 28
+    error_message = "budget_processing_period_start_offset must be between 1 and 28."
+  }
 }
 
 variable "budget_processing_period_type" {
@@ -136,6 +156,10 @@ variable "budget_target_type" {
 }
 
 variable "budget_targets" {
-  description = "(Optional) The list of targets on which the budget is applied. If targetType is 'COMPARTMENT', the targets contain the list of compartment OCIDs. If targetType is 'TAG', the targets contain the list of cost tracking tag identifiers in the form of '{tagNamespace}.{tagKey}.{tagValue}'. Curerntly, the array should contain exactly one item."
+  description = "(Optional) The list of targets on which the budget is applied. If targetType is 'COMPARTMENT', the targets contain the list of compartment OCIDs. If targetType is 'TAG', the targets contain the list of cost tracking tag identifiers in the form of '{tagNamespace}.{tagKey}.{tagValue}'. Currently, the array should contain exactly one item."
   type        = list(string)
+  validation {
+    condition     = length(var.budget_targets) == 1
+    error_message = "budget_targets must contain exactly one item."
+  }
 }


### PR DESCRIPTION
## Summary

- Fixes `alert_display_name` default from `"Alert on $0.01 forecast spend"` to `"Alert_on_0.01_forecast_spend"` — OCI only permits `a-zA-Z0-9.-_` characters in display names
- Adds regex validation to `alert_display_name` and `budget_display_name` enforcing the OCI character constraint
- Adds `alert_threshold > 0` validation
- Adds OCID format validation to `budget_compartment_id`
- Adds range validation to `budget_processing_period_start_offset` (1–28, safe for all months including February)
- Adds `length == 1` validation to `budget_targets` (OCI API only accepts exactly one target)

## Test plan

- [ ] `terraform validate` passes in consumers of this module
- [ ] Apply with valid inputs succeeds
- [ ] Apply with invalid `alert_display_name` (e.g. containing spaces or `$`) is caught at plan time with a clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)