### PR TITLE
docs: add Kubernetes on OCI Free Tier implementation plan

### DIFF
--- a/docs/plans/2026-04-04-kubernetes-on-oci-free-tier-plan.md
+++ b/docs/plans/2026-04-04-kubernetes-on-oci-free-tier-plan.md
@@ -115,7 +115,7 @@
 | Parameter | Value | Rationale |
 |-----------|-------|-----------|
 | Cluster type | `BASIC_CLUSTER` | Free; Enhanced adds SLA + features at extra cost |
-| K8s version | Latest stable (e.g., v1.33.x) | Query via `oci ce cluster-options list` |
+| K8s version | Latest stable (e.g., v1.33.x) | Query via `oci ce cluster-options get --cluster-option-id all --compartment-id <compartment-id>` |
 | Pod CIDR | `10.244.0.0/16` | Standard, non-overlapping with VCN |
 | Service CIDR | `10.96.0.0/16` | Standard Kubernetes default |
 | CNI | Flannel (default) | VCN-native requires pod subnet (more complex) |
@@ -983,7 +983,7 @@ Each new module gets a `tests/<module>.tftest.hcl` file with:
 
 | Check | How |
 |-------|-----|
-| Block storage <= 200 GB | `oci bv volume list --compartment-id <id> \| jq '[.data[]."size-in-gbs"] \| add'` |
+| Block storage <= 200 GB | `oci bv volume list --compartment-id <id> \| jq '[.data[]."size-in-gbs"] \| add // 0'` |
 | Compute instances within limits | `oci compute instance list --compartment-id <id> \| jq '.data[] \| {shape: .shape, state: ."lifecycle-state"}'` |
 | LB count <= 1 | `oci lb load-balancer list --compartment-id <id> \| jq '.data \| length'` |
 | NLB count <= 1 | `oci nlb network-load-balancer list --compartment-id <id> \| jq '.data \| length'` |


### PR DESCRIPTION
## Summary

- Adds `docs/plans/2026-04-04-kubernetes-on-oci-free-tier-plan.md` — a comprehensive, research-backed plan for deploying Kubernetes on OCI Always Free Tier at $0 cost
- Covers two approaches: **OKE** (managed, recommended first) and **self-managed K3s** via Terraform 1.14 `action` blocks + k3s-ansible
- Defines 5 new modules to build in this repo across 3 phases

## What's in the plan

| Section | Content |
|---------|---------|
| Executive Summary | OKE first (simpler, 2 new modules), K3s second (3 new modules, uses AMD Micro instances) |
| Free Tier Resource Mapping | Exact tables: Arm 4 OCPU/24 GB, 200 GB block storage, 1 flex LB, 2 VCNs |
| OKE Deep Dive | 3-subnet architecture, NSG rules for API endpoint/workers/LB, cluster + node pool config |
| K3s Deep Dive | 4-node topology (storage-limited: 4×50 GB = 200 GB), Ansible provider `action` block, k3s-ansible playbook structure |
| Comparison Matrix | 16-dimension side-by-side (cost, control plane, upgrades, networking, OCI integrations) |
| Module Development Plan | 5 modules with full variable/output specs and test scenarios |
| Example Implementations | `examples/free-tier-kubernetes-oke` and `examples/free-tier-k3s-cluster` with complete `main.tf` |
| Testing Strategy | Native TF tests per module + integration tests + free tier compliance checks |
| Risks & Mitigations | Idle reclamation, A1.Flex capacity limits, TF 1.14 `action` maturity, Ansible dependency |

## New modules identified (not implemented in this PR)

| Phase | Module | Purpose |
|-------|--------|---------|
| 1 | `oci/network_security_group` | NSG with configurable ingress/egress rules (OKE + K3s) |
| 1 | `oci/security_list` | Standalone security list with rules (K3s) |
| 2 | `oci/oke_cluster` | OKE cluster (`oci_containerengine_cluster`) |
| 2 | `oci/oke_node_pool` | OKE node pool (`oci_containerengine_node_pool`) |
| 3 | `oci/k3s_cluster` | Composite module: runs k3s-ansible via Ansible provider `action` block |

## Test plan

- [ ] Plan document renders correctly in GitHub markdown
- [ ] All referenced module outputs (`public_route_table_id`, `subnet_id`, `instance_public_ip`, etc.) verified to exist in this repo ✅
- [ ] Cross-repo reference to `2026-04-02-oci-free-tier-modules-plan.md` verified to exist ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)