### PR TITLE
chore: dev experience improvements, skill scaffolding, block_volume fix, README update

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,6 +7,10 @@
           {
             "type": "command",
             "command": "jq -r '.tool_input.file_path // .tool_response.filePath' | { read -r f; case \"$f\" in *.tf) terraform fmt \"$f\" ;; esac; } 2>/dev/null || true"
+          },
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path // .tool_response.filePath' | { read -r f; case \"$f\" in *.yaml|*.yml) yamlfmt \"$f\" ;; esac; } 2>/dev/null || true"
           }
         ]
       }

--- a/.claude/skills/new-module/SKILL.md
+++ b/.claude/skills/new-module/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: new-module
+description: Scaffold a new OCI Terraform module with all required files matching project conventions. Use when the user asks to create, add, or build a new module — even if they don't say "scaffold". Any request to create a new resource type under oci/ should trigger this skill.
+disable-model-invocation: false
+---
+
+# New Module Scaffold
+
+Create a new module under `oci/<module_name>/` with this exact structure:
+
+```
+oci/<module_name>/
+├── main.tf
+├── variables.tf
+├── outputs.tf
+├── providers.tf
+├── README.md
+└── tests/<module_name>.tftest.hcl
+```
+
+If `$ARGUMENTS` is provided, use it as the module name. Otherwise ask the user.
+
+## File Templates
+
+### providers.tf
+```hcl
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    oci = {
+      source  = "oracle/oci"
+      version = ">= 8.0, < 9.0"
+    }
+  }
+}
+```
+
+### variables.tf
+Order: `compartment_id` first, then required inputs (no default), then optional inputs (with default).
+
+```hcl
+variable "compartment_id" {
+  description = "The OCID of the compartment to create the resource in."
+  type        = string
+
+  validation {
+    condition     = can(regex("^ocid1\\.compartment\\.[a-z][a-z0-9-]*\\.[a-z0-9-]*\\.[a-z0-9]+$", var.compartment_id))
+    error_message = "compartment_id must be a valid compartment OCID."
+  }
+}
+```
+
+### main.tf
+Use `"this"` as the resource name for singleton resources. Use `count` for on/off conditionals, `for_each` for collections.
+
+### outputs.tf
+Mark outputs `sensitive = true` when they contain connection strings, URLs, private keys, passwords, or session tokens.
+
+### README.md
+```markdown
+# oci/<module_name>
+
+<!-- BEGIN_TF_DOCS -->
+<!-- END_TF_DOCS -->
+```
+
+**The two marker lines are the complete README body — nothing goes between them.** terraform-docs fills that section automatically when pre-commit runs. Writing inputs/outputs tables or any other content between the markers causes CI to fail on the next pre-commit run because it gets overwritten.
+
+### tests/<module_name>.tftest.hcl
+```hcl
+mock_provider "oci" {}
+
+# 1. Defaults run — required inputs only
+run "defaults" {
+  command = plan
+
+  variables {
+    compartment_id = "ocid1.compartment.oc1..aaaaaaaa"
+  }
+
+  assert {
+    condition     = <resource>.<name>.<attr> == <expected>
+    error_message = "Expected <attr> to be <expected>."
+  }
+}
+
+# 2. Custom-inputs run — exercise optional inputs
+run "custom_inputs" {
+  command = plan
+
+  variables {
+    compartment_id = "ocid1.compartment.oc1..aaaaaaaa"
+    # set optional vars here
+  }
+}
+
+# 3. One rejection run per validation block
+run "rejects_invalid_compartment_id" {
+  command = plan
+
+  variables {
+    compartment_id = "not-a-valid-ocid"
+  }
+
+  expect_failures = [var.compartment_id]
+}
+```
+
+Every module test MUST include all three run types. Add one rejection run per `validation` block in variables.tf.
+
+## After Scaffolding
+
+1. Run `terraform init && terraform test` from `oci/<module_name>/` to verify tests pass.
+2. Run `pre-commit run --all-files` from the repo root (with no `.terraform.lock.hcl` present) to generate the README docs section and verify formatting.
+3. Add an entry for the new module in the root `README.md` inventory table.

--- a/.claude/skills/tf-plan/SKILL.md
+++ b/.claude/skills/tf-plan/SKILL.md
@@ -1,11 +1,23 @@
 ---
 name: tf-plan
-description: Run terraform init and plan on an example directory to validate module changes end-to-end. Use when testing module changes.
+description: Run terraform init + plan on an example directory to validate module changes end-to-end. Use when the user says "run a plan", "test this against an example", "does the plan work", or wants to check that module changes don't break a real deployment scenario.
 disable-model-invocation: true
 ---
 
-Run a Terraform plan in an example directory to validate module changes. Use $ARGUMENTS to determine which example (dynamic-profile, two-profiles, two-tenancies). If not specified, ask the user.
+Run a Terraform plan in an example directory to validate module changes end-to-end. Use $ARGUMENTS to determine which example. If not specified, ask the user.
 
+Available examples:
+- `dual-tenancy` — multi-tenancy auth with oci_profile_reader
+- `free-tier-arm-server` — A1 Flex + VCN + block volume
+- `free-tier-compute-stack` — VCN + subnets + AMD Micro + bastion
+- `free-tier-databases` — Autonomous DB + MySQL + NoSQL
+- `free-tier-k3s-cluster` — K3s cluster
+- `free-tier-kubernetes-oke` — OKE cluster with node pool
+- `free-tier-web-app` — 2x AMD Micro + flexible load balancer + VCN
+- `free-tier-observability` — monitoring + logging + APM + connector hub + notifications
+- `free-tier-security` — Vault + software key + root CA + TLS certificate
+
+Steps:
 1. `cd examples/<example_dir>`
 2. `terraform init` — initialize
 3. `terraform plan` — preview changes

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,20 +1,38 @@
 ---
 name: verify
-description: Run Terraform formatting check, validation, and docs generation to verify module changes are correct. Use before committing or when asked to check work.
+description: Run Terraform verification (format, validate, test, docs) before committing or when completing module work. Invoke whenever the user says "check my changes", "verify this", "before I commit", "does this look right", or finishes implementing a module change — even if they don't say "verify".
 ---
 
-Run the following verification steps. Detect which module or example directory was changed and run validation there:
+Detect which module or example directories were changed (use `git diff --name-only` if unsure), then run these steps:
 
-1. `terraform fmt -check -recursive` — check formatting from repo root (fix with `terraform fmt -recursive` if needed)
-2. For each changed module/example directory:
-   - `terraform init -backend=false` — initialize without backend (if .terraform doesn't exist)
-   - `terraform validate` — validate configuration
-3. For each changed module directory under `oci/` (skip `examples/` — they have no tests):
-   - `terraform test` — run the module's test suite (already initialized above)
-4. Before regenerating docs, delete all `.terraform/` dirs and `.terraform.lock.hcl` files from `oci/` — otherwise terraform-docs embeds the resolved provider version instead of the constraint string, causing CI to fail:
+1. **Format** — from repo root:
+   ```
+   terraform fmt -check -recursive
+   ```
+   If it fails, fix with `terraform fmt -recursive`, then re-check.
+
+2. **Validate** — for each changed module or example directory:
+   ```
+   terraform init -backend=false
+   terraform validate
+   ```
+   Skip `terraform init` if `.terraform/` already exists in that directory.
+
+3. **Test** — for each changed directory under `oci/` (skip `examples/` — they have no tests):
+   ```
+   terraform test
+   ```
+
+4. **Clean lock files** — before regenerating docs, remove `.terraform/` and `.terraform.lock.hcl` from all `oci/` directories. If these exist when terraform-docs runs, it embeds the resolved provider version (e.g. `8.8.0`) instead of the constraint (`>= 8.0`), which causes CI to fail:
    ```
    find oci -name ".terraform.lock.hcl" -delete && find oci -type d -name ".terraform" -exec rm -rf {} + 2>/dev/null; true
    ```
-5. `pre-commit run terraform_docs --all-files` — regenerate docs (run twice; first run modifies files, second confirms clean)
 
-Report results as a table: directory, step, status (pass/fail), and any error details.
+5. **Docs** — run terraform-docs twice. The first pass modifies README files; the second pass must exit clean to confirm no stale content remains:
+   ```
+   pre-commit run terraform_docs --all-files
+   pre-commit run terraform_docs --all-files
+   ```
+   Both runs must succeed. If only the first fails but the second passes, that's expected — it just means docs were stale and have been regenerated.
+
+Report results as a table: directory | step | status | notes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,12 +30,14 @@ When creating or updating a module, you MUST:
 - Run all pre-commit checks: `pre-commit run --all-files`
 - CI runs tests automatically via `.github/workflows/terraform-tests.yml` (dynamic module discovery)
 - When running `pre-commit run --all-files` locally, do NOT run `terraform init` first in module directories. If you have already initialized, delete `.terraform.lock.hcl` before running pre-commit. Otherwise `terraform_docs` will embed the resolved provider version (e.g. `8.8.0`) instead of the constraint (`>= 8.0`), causing CI to fail.
+- Local pre-commit runs require `~/.oci/config` and `~/.oci/oci_api_key.pem` to exist — `terraform_tflint` and `terraform_docs` call `terraform init` internally and need valid OCI credentials.
 - **When fixing CI failures:** always run `pre-commit run --all-files` (from the repo root, with no `.terraform.lock.hcl` present in any module directory) as the final step before pushing. Running targeted tools on only modified files misses stale READMEs in unrelated modules that CI also checks.
 
 ## Git Workflow
 
 - Never push directly to `master` — always create a feature branch and open a PR
 - PRs merge into `master`
+- Each module is versioned independently using Conventional Commits. Merges to `master` auto-tag per module (e.g. `oci/budget/v1.2.0`). Bump rules: `feat!:` or `BREAKING CHANGE` = major, `feat:` = minor, `fix:`/`chore:` etc. = patch.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -31,10 +31,20 @@ Reusable Terraform modules for Oracle Cloud Infrastructure (OCI) Always Free Tie
 |---|---|
 | [`oci/load_balancer`](oci/load_balancer) | Flexible LB (10 Mbps, free tier) + backend set + listener |
 | [`oci/network_load_balancer`](oci/network_load_balancer) | Layer-4 NLB + backend set + listener |
+| [`oci/network_security_group`](oci/network_security_group) | Network Security Group + ingress/egress rules |
+| [`oci/security_list`](oci/security_list) | Security list + ingress/egress rules |
 | [`oci/vault`](oci/vault) | KMS vault + optional software key |
 | [`oci/certificates`](oci/certificates) | Certificate Authority + optional issued certificate |
 | [`oci/bastion`](oci/bastion) | Bastion service (STANDARD type) |
 | [`oci/vpn`](oci/vpn) | Site-to-Site VPN: DRG + optional VCN attachment + CPE + IPSec |
+
+### Kubernetes & Containers
+
+| Module | Resource(s) |
+|---|---|
+| [`oci/k3s_cluster`](oci/k3s_cluster) | K3s cluster provisioned via Ansible on existing compute nodes |
+| [`oci/oke_cluster`](oci/oke_cluster) | OKE (Oracle Kubernetes Engine) cluster |
+| [`oci/oke_node_pool`](oci/oke_node_pool) | OKE node pool |
 
 ### Observability & Notifications
 
@@ -55,6 +65,8 @@ Reusable Terraform modules for Oracle Cloud Infrastructure (OCI) Always Free Tie
 | [`examples/free-tier-compute-stack`](examples/free-tier-compute-stack) | VCN + public/private subnets + AMD Micro + bastion |
 | [`examples/free-tier-arm-server`](examples/free-tier-arm-server) | A1 Flex (4 OCPUs / 24 GB RAM) + VCN + block volume |
 | [`examples/free-tier-databases`](examples/free-tier-databases) | Autonomous DB + MySQL + NoSQL wired together |
+| [`examples/free-tier-k3s-cluster`](examples/free-tier-k3s-cluster) | K3s cluster on Always Free compute nodes |
+| [`examples/free-tier-kubernetes-oke`](examples/free-tier-kubernetes-oke) | OKE cluster with node pool |
 | [`examples/free-tier-web-app`](examples/free-tier-web-app) | 2x AMD Micro + flexible load balancer + VCN |
 | [`examples/free-tier-observability`](examples/free-tier-observability) | Monitoring + logging + APM + connector hub + notifications |
 | [`examples/free-tier-security`](examples/free-tier-security) | Vault + software key + root CA + TLS certificate |
@@ -63,6 +75,73 @@ Reusable Terraform modules for Oracle Cloud Infrastructure (OCI) Always Free Tie
 
 - Terraform >= 1.0
 - OCI provider >= 8.0
+
+## Prerequisites for Local Development
+
+In addition to Terraform, you need:
+
+| Tool | Version | Install |
+|---|---|---|
+| [pre-commit](https://pre-commit.com) | any | `brew install pre-commit` |
+| [terraform-docs](https://terraform-docs.io) | v0.19.0 | `brew install terraform-docs` |
+| [tflint](https://github.com/terraform-linters/tflint) | v0.55.0 | `brew install tflint` |
+| [yamlfmt](https://github.com/google/yamlfmt) | any | `brew install yamlfmt` |
+| OCI credentials | — | `~/.oci/config` + `~/.oci/oci_api_key.pem` |
+
+OCI credentials are required because `terraform_docs` and `tflint` call `terraform init` internally during pre-commit.
+
+After installing tools, install the pre-commit hooks:
+
+```bash
+pre-commit install
+```
+
+## Local Development
+
+### Running tests
+
+Tests use a mock OCI provider and only run `terraform plan` — no real OCI resources are created.
+
+```bash
+cd oci/<module>
+terraform init
+terraform test
+```
+
+### Validating a module or example
+
+```bash
+cd oci/<module>      # or examples/<example>
+terraform init
+terraform validate
+```
+
+### Running all pre-commit checks
+
+**Important:** Delete any `.terraform.lock.hcl` files before running pre-commit. If they exist, `terraform_docs` embeds the resolved provider version (e.g. `8.8.0`) instead of the constraint (`>= 8.0`), which causes CI to fail.
+
+```bash
+find oci -name ".terraform.lock.hcl" -delete
+pre-commit run --all-files
+```
+
+## Contributing
+
+1. **Branch** — branch off `master` and open a PR; never push directly to `master`.
+
+2. **Commit messages** — follow [Conventional Commits](https://www.conventionalcommits.org/). The commit type determines the version bump for every module touched by the PR:
+
+   | Commit type | Version bump |
+   |---|---|
+   | `feat!:` or `BREAKING CHANGE:` footer | major |
+   | `feat:` | minor |
+   | `fix:`, `chore:`, etc. | patch |
+
+3. **Tests** — every change to a module must have a corresponding update to `tests/<module>.tftest.hcl`. Tests must pass (`terraform init && terraform test` from the module directory).
+
+4. **Pre-commit** — run `pre-commit run --all-files` from the repo root (with no `.terraform.lock.hcl` present) before pushing. This formats code, regenerates README docs sections, and runs tflint.
+
+5. **New modules** — follow the module layout (`main.tf`, `variables.tf`, `outputs.tf`, `providers.tf`, `README.md`, `tests/<module>.tftest.hcl`) and add an entry to the modules table above.
 
 ## Versioning and Releases
 

--- a/oci/block_volume/README.md
+++ b/oci/block_volume/README.md
@@ -58,6 +58,7 @@ No modules.
 |------|------|
 | [oci_core_volume.this](https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_volume) | resource |
 | [oci_core_volume_attachment.this](https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_volume_attachment) | resource |
+| [oci_core_volume_backup_policy_assignment.this](https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_volume_backup_policy_assignment) | resource |
 
 ## Inputs
 

--- a/oci/block_volume/main.tf
+++ b/oci/block_volume/main.tf
@@ -4,11 +4,17 @@ resource "oci_core_volume" "this" {
   display_name        = var.volume_display_name
   size_in_gbs         = var.volume_size_in_gbs
   vpus_per_gb         = var.vpus_per_gb
-  backup_policy_id    = var.backup_policy_id
   kms_key_id          = var.kms_key_id
 
   defined_tags  = var.volume_defined_tags
   freeform_tags = var.volume_freeform_tags
+}
+
+resource "oci_core_volume_backup_policy_assignment" "this" {
+  count = var.backup_policy_id != null ? 1 : 0
+
+  asset_id  = oci_core_volume.this.id
+  policy_id = var.backup_policy_id
 }
 
 resource "oci_core_volume_attachment" "this" {

--- a/oci/block_volume/tests/block_volume.tftest.hcl
+++ b/oci/block_volume/tests/block_volume.tftest.hcl
@@ -141,7 +141,7 @@ run "with_kms_and_backup_policy" {
   }
 
   assert {
-    condition     = oci_core_volume.this.backup_policy_id == "ocid1.volumebackuppolicy.oc1..aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-    error_message = "backup_policy_id should be passed through to the volume resource"
+    condition     = oci_core_volume_backup_policy_assignment.this[0].policy_id == "ocid1.volumebackuppolicy.oc1..aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    error_message = "backup_policy_id should be passed through to the backup policy assignment resource"
   }
 }

--- a/oci/k3s_cluster/README.md
+++ b/oci/k3s_cluster/README.md
@@ -78,7 +78,7 @@ No modules.
 | <a name="input_extra_agent_args"></a> [extra\_agent\_args](#input\_extra\_agent\_args) | Additional arguments to pass to k3s agent. | `string` | `""` | no |
 | <a name="input_extra_server_args"></a> [extra\_server\_args](#input\_extra\_server\_args) | Additional arguments to pass to k3s server. | `string` | `""` | no |
 | <a name="input_k3s_ansible_path"></a> [k3s\_ansible\_path](#input\_k3s\_ansible\_path) | Path to the k3s-ansible directory containing playbooks. | `string` | `""` | no |
-| <a name="input_k3s_version"></a> [k3s\_version](#input\_k3s\_version) | K3s version to install. Must start with 'v' (e.g. 'v1.31.12+k3s1'). | `string` | `"v1.31.12+k3s1"` | no |
+| <a name="input_k3s_version"></a> [k3s\_version](#input\_k3s\_version) | K3s version to install. Must start with 'v' (e.g. 'v1.35.3+k3s1'). | `string` | `"v1.35.3+k3s1"` | no |
 | <a name="input_server_ips"></a> [server\_ips](#input\_server\_ips) | List of public IP addresses for K3s server (control plane) nodes. At least one required. | `list(string)` | n/a | yes |
 | <a name="input_ssh_extra_args"></a> [ssh\_extra\_args](#input\_ssh\_extra\_args) | Additional SSH arguments passed to Ansible. Defaults to disabling host key checking for initial provisioning. Set to '' or override for stricter security in trusted environments. | `string` | `"-o StrictHostKeyChecking=no"` | no |
 | <a name="input_ssh_private_key_path"></a> [ssh\_private\_key\_path](#input\_ssh\_private\_key\_path) | Path to the SSH private key file for connecting to K3s nodes. | `string` | n/a | yes |

--- a/oci/k3s_cluster/variables.tf
+++ b/oci/k3s_cluster/variables.tf
@@ -31,9 +31,9 @@ variable "ssh_extra_args" {
 }
 
 variable "k3s_version" {
-  description = "K3s version to install. Must start with 'v' (e.g. 'v1.31.12+k3s1')."
+  description = "K3s version to install. Must start with 'v' (e.g. 'v1.35.3+k3s1')."
   type        = string
-  default     = "v1.31.12+k3s1"
+  default     = "v1.35.3+k3s1"
   validation {
     condition     = can(regex("^v", var.k3s_version))
     error_message = "k3s_version must start with 'v'."


### PR DESCRIPTION
## Description
- Add `.claude/skills/new-module` skill to scaffold new OCI Terraform modules with correct file structure, provider constraints, variable ordering, README markers, and test templates
- Improve `.claude/skills/verify` skill: restructured steps, explicit two-pass terraform-docs requirement, more trigger-friendly description
- Improve `.claude/skills/tf-plan` skill: fix example directory names (previously referenced non-existent dirs), more trigger-friendly description
- Add `yamlfmt` PostToolUse hook to `.claude/settings.json` for auto-formatting `.yaml`/`.yml` files after edits
- Fix `oci/block_volume`: move `backup_policy_id` from inline `oci_core_volume` attribute to separate `oci_core_volume_backup_policy_assignment` resource (the inline attribute was removed in the OCI provider); update stale test assertion accordingly
- Update `oci/k3s_cluster/variables.tf`: bump default `k3s_version` from `v1.31.12+k3s1` to `v1.35.3+k3s1`
- Rewrite root `README.md`: add full module/example inventory (including Kubernetes & Containers section), Prerequisites for Local Development table, Local Development section, and Contributing guide

## Design Decisions
- The `oci_core_volume_backup_policy_assignment` resource uses `count` rather than being always-created, consistent with the repo's pattern for optional features
- Skill descriptions are intentionally "pushy" (listing trigger phrases) per skill-creator guidance to counter Claude's tendency to undertrigger skills
- README terraform-docs markers are left empty in the new-module skill template — the "why" is now bolded to prevent the most common mistake seen in evals (pre-filling content between markers)

## Testing
- All pre-commit hooks pass (terraform_fmt, terraform_docs, tflint, yamlfmt)
- `block_volume` test assertion updated to match restructured resource