### PR TITLE
chore: add backup_policy_assignment_id output, strengthen OCID validation, expand block_volume tests

### DIFF
--- a/.claude/skills/new-module/SKILL.md
+++ b/.claude/skills/new-module/SKILL.md
@@ -45,8 +45,8 @@ variable "compartment_id" {
   type        = string
 
   validation {
-    condition     = can(regex("^ocid1\\.compartment\\.[a-z][a-z0-9-]*\\.[a-z0-9-]*\\.[a-z0-9]+$", var.compartment_id))
-    error_message = "compartment_id must be a valid compartment OCID."
+    condition     = can(regex("^ocid1\\.[a-z]+\\.[a-z][a-z0-9-]*\\.[a-z0-9-]*\\.[a-z0-9]+$", var.compartment_id))
+    error_message = "compartment_id must be a valid OCI OCID (e.g. ocid1.compartment.oc1..aaaaaa...)."
   }
 }
 ```
@@ -76,7 +76,7 @@ run "defaults" {
   command = plan
 
   variables {
-    compartment_id = "ocid1.compartment.oc1..aaaaaaaa"
+    compartment_id = "ocid1.compartment.oc1..aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
   }
 
   assert {
@@ -90,7 +90,7 @@ run "custom_inputs" {
   command = plan
 
   variables {
-    compartment_id = "ocid1.compartment.oc1..aaaaaaaa"
+    compartment_id = "ocid1.compartment.oc1..aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     # set optional vars here
   }
 }

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ In addition to Terraform, you need:
 
 OCI credentials are required because `terraform_docs` and `tflint` call `terraform init` internally during pre-commit.
 
+The pinned versions for `terraform-docs` and `tflint` match what CI uses (see `.github/workflows/pre-commit.yml`). Using different local versions may produce output that diverges from CI.
+
 After installing tools, install the pre-commit hooks:
 
 ```bash

--- a/oci/block_volume/README.md
+++ b/oci/block_volume/README.md
@@ -81,6 +81,7 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_backup_policy_assignment_id"></a> [backup\_policy\_assignment\_id](#output\_backup\_policy\_assignment\_id) | OCID of the volume backup policy assignment. Returns null when no backup\_policy\_id is provided. |
 | <a name="output_volume_attachment_id"></a> [volume\_attachment\_id](#output\_volume\_attachment\_id) | OCID of the volume attachment. Returns null when no instance\_id is provided. |
 | <a name="output_volume_id"></a> [volume\_id](#output\_volume\_id) | OCID of the block volume. |
 <!-- END_TF_DOCS -->

--- a/oci/block_volume/outputs.tf
+++ b/oci/block_volume/outputs.tf
@@ -7,3 +7,8 @@ output "volume_attachment_id" {
   description = "OCID of the volume attachment. Returns null when no instance_id is provided."
   value       = try(oci_core_volume_attachment.this[0].id, null)
 }
+
+output "backup_policy_assignment_id" {
+  description = "OCID of the volume backup policy assignment. Returns null when no backup_policy_id is provided."
+  value       = try(oci_core_volume_backup_policy_assignment.this[0].id, null)
+}

--- a/oci/block_volume/tests/block_volume.tftest.hcl
+++ b/oci/block_volume/tests/block_volume.tftest.hcl
@@ -22,6 +22,11 @@ run "default_volume_no_attachment" {
     condition     = length(oci_core_volume_attachment.this) == 0
     error_message = "No attachment should be created when instance_id is null"
   }
+
+  assert {
+    condition     = length(oci_core_volume_backup_policy_assignment.this) == 0
+    error_message = "No backup policy assignment should be created when backup_policy_id is null"
+  }
 }
 
 run "accepts_vpus_zero" {
@@ -141,7 +146,48 @@ run "with_kms_and_backup_policy" {
   }
 
   assert {
+    condition     = length(oci_core_volume_backup_policy_assignment.this) == 1
+    error_message = "Exactly one backup policy assignment should be created when backup_policy_id is provided"
+  }
+
+  assert {
     condition     = oci_core_volume_backup_policy_assignment.this[0].policy_id == "ocid1.volumebackuppolicy.oc1..aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     error_message = "backup_policy_id should be passed through to the backup policy assignment resource"
   }
+}
+
+run "rejects_invalid_backup_policy_id" {
+  command = plan
+
+  variables {
+    backup_policy_id = "not-a-valid-ocid"
+  }
+
+  expect_failures = [
+    var.backup_policy_id,
+  ]
+}
+
+run "rejects_invalid_kms_key_id" {
+  command = plan
+
+  variables {
+    kms_key_id = "not-a-valid-ocid"
+  }
+
+  expect_failures = [
+    var.kms_key_id,
+  ]
+}
+
+run "rejects_empty_availability_domain" {
+  command = plan
+
+  variables {
+    availability_domain = "   "
+  }
+
+  expect_failures = [
+    var.availability_domain,
+  ]
 }


### PR DESCRIPTION
## Summary

- Add `backup_policy_assignment_id` output to the `block_volume` module
- Strengthen OCID validation in the `new-module` skill and expand `block_volume` test coverage
- Minor README documentation improvements

## Changes

### `oci/block_volume`

- **`outputs.tf`** — added `backup_policy_assignment_id` output (returns `null` when no `backup_policy_id` provided)
- **`README.md`** — auto-generated docs updated to include the new output
- **`tests/block_volume.tftest.hcl`**:
  - Added assertion in `default_volume_no_attachment` run: no backup policy assignment created when `backup_policy_id` is null
  - Added count assertion in `with_kms_and_backup_policy` run: exactly one assignment created
  - Added rejection run for invalid `backup_policy_id`
  - Added rejection run for invalid `kms_key_id`
  - Added rejection run for empty `availability_domain`

### `.claude/skills/new-module`

- Broadened OCID validation regex from compartment-specific (`ocid1\.compartment\.…`) to generic OCI pattern (`ocid1\.[a-z]+\.…`) — matches all resource types
- Improved error message to include an example OCID
- Fixed test fixture `compartment_id` values to use full-length OCIDs (matching actual OCI format)

### `README.md`

- Added note that pinned `terraform-docs` and `tflint` versions match CI (`.github/workflows/pre-commit.yml`) to explain why version alignment matters

## Testing

- `terraform init && terraform test` passes in `oci/block_volume/`
- `pre-commit run --all-files` passes from repo root (no `.terraform.lock.hcl` present)