### PR TITLE
chore: add tflint manager to Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,8 @@
   "enabledManagers": [
     "github-actions",
     "pre-commit",
-    "terraform"
+    "terraform",
+    "tflint"
   ],
   "packageRules": [
     {
@@ -35,6 +36,18 @@
         "patch"
       ],
       "groupName": "pre-commit hooks",
+      "automerge": true
+    },
+    {
+      "description": "Group tflint plugin updates and automerge minor/patch",
+      "matchManagers": [
+        "tflint"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "groupName": "tflint plugins",
       "automerge": true
     },
     {


### PR DESCRIPTION
## Description
- Add `tflint` to `enabledManagers` so Renovate tracks plugin versions pinned in `.tflint.hcl`
- Add a `packageRule` to group and automerge minor/patch tflint plugin updates (consistent with the existing rules for other managers)

## Design Decisions
- The `tflint-ruleset-oci` plugin in `.tflint.hcl` was pinned at `0.1.2` with no automated update path — this closes that gap

## Testing
- Pre-commit hooks passed on commit