### PR TITLE
fix: correct Renovate manager name tflint -> tflint-plugin

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,7 @@
     "github-actions",
     "pre-commit",
     "terraform",
-    "tflint"
+    "tflint-plugin"
   ],
   "packageRules": [
     {
@@ -41,7 +41,7 @@
     {
       "description": "Group tflint plugin updates and automerge minor/patch",
       "matchManagers": [
-        "tflint"
+        "tflint-plugin"
       ],
       "matchUpdateTypes": [
         "minor",


### PR DESCRIPTION
## Description
- Fix the Renovate config error from #46 — the correct manager name is `tflint-plugin`, not `tflint`

## Design Decisions
- N/A — straight rename to the documented manager name per [Renovate docs](https://github.com/renovatebot/renovate/blob/main/lib/modules/manager/tflint-plugin/readme.md)

## Testing
- Closes #47 — Renovate will re-validate the config on merge and clear the blocking error