### PR TITLE
fix(vcn): gate Service Gateway route on public RT behind opt-in flag

### DIFF
--- a/oci/vcn/README.md
+++ b/oci/vcn/README.md
@@ -51,10 +51,11 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_add_service_gateway_to_public_rt"></a> [add\_service\_gateway\_to\_public\_rt](#input\_add\_service\_gateway\_to\_public\_rt) | (Optional) Whether to add a Service Gateway route to the public route table. Defaults to false because OCI rejects combining an Internet Gateway and an 'All Services' Service Gateway route in the same route table. | `bool` | `false` | no |
 | <a name="input_compartment_id"></a> [compartment\_id](#input\_compartment\_id) | (Required) The OCID of the compartment in which to create the VCN. | `string` | n/a | yes |
 | <a name="input_create_internet_gateway"></a> [create\_internet\_gateway](#input\_create\_internet\_gateway) | (Optional) Whether to create an Internet Gateway and public route table. Defaults to false (secure). Set to true only for subnets that must be reachable from the internet. | `bool` | `false` | no |
 | <a name="input_create_nat_gateway"></a> [create\_nat\_gateway](#input\_create\_nat\_gateway) | (Optional) Whether to create a NAT Gateway and private route table. | `bool` | `false` | no |
-| <a name="input_create_service_gateway"></a> [create\_service\_gateway](#input\_create\_service\_gateway) | (Optional) Whether to create a Service Gateway. When enabled, a service route is added to the public and/or private route tables. | `bool` | `false` | no |
+| <a name="input_create_service_gateway"></a> [create\_service\_gateway](#input\_create\_service\_gateway) | (Optional) Whether to create a Service Gateway. When enabled, a service route is added to the private route table (and optionally the public route table — see add\_service\_gateway\_to\_public\_rt). | `bool` | `false` | no |
 | <a name="input_vcn_cidr_blocks"></a> [vcn\_cidr\_blocks](#input\_vcn\_cidr\_blocks) | (Optional) (Updatable) The list of one or more IPv4 CIDR blocks for the VCN. | `list(string)` | <pre>[<br/>  "10.0.0.0/16"<br/>]</pre> | no |
 | <a name="input_vcn_defined_tags"></a> [vcn\_defined\_tags](#input\_vcn\_defined\_tags) | (Optional) (Updatable) Defined tags for all resources created by this module (VCN, gateways, route tables, and security list). | `map(string)` | `{}` | no |
 | <a name="input_vcn_display_name"></a> [vcn\_display\_name](#input\_vcn\_display\_name) | (Optional) (Updatable) A user-friendly name for the VCN. | `string` | `"vcn"` | no |

--- a/oci/vcn/main.tf
+++ b/oci/vcn/main.tf
@@ -75,7 +75,7 @@ resource "oci_core_route_table" "public" {
   }
 
   dynamic "route_rules" {
-    for_each = var.create_service_gateway ? [1] : []
+    for_each = var.create_service_gateway && var.add_service_gateway_to_public_rt ? [1] : []
     content {
       destination       = local.service.cidr_block
       destination_type  = "SERVICE_CIDR_BLOCK"

--- a/oci/vcn/main.tf
+++ b/oci/vcn/main.tf
@@ -82,6 +82,13 @@ resource "oci_core_route_table" "public" {
       network_entity_id = oci_core_service_gateway.this[0].id
     }
   }
+
+  lifecycle {
+    precondition {
+      condition     = !var.add_service_gateway_to_public_rt || var.create_service_gateway
+      error_message = "add_service_gateway_to_public_rt requires create_service_gateway = true."
+    }
+  }
 }
 
 resource "oci_core_route_table" "private" {

--- a/oci/vcn/tests/vcn.tftest.hcl
+++ b/oci/vcn/tests/vcn.tftest.hcl
@@ -113,13 +113,38 @@ run "all_gateways" {
     error_message = "Private route table should be created"
   }
 
-  # Verify that the service gateway is wired into both route tables by confirming
-  # the SGW variable is true (which drives the dynamic route_rules blocks). A
+  # Verify that the service gateway is wired into the private route table by confirming
+  # the SGW variable is true (which drives the dynamic route_rules block). A
   # length() check on route_rules cannot be used at plan time because the
-  # network_entity_id values are computed and unknown until apply.
+  # network_entity_id values are computed and unknown until apply. The public RT
+  # opt-in (add_service_gateway_to_public_rt) defaults to false and is tested
+  # separately in the sgw_in_public_rt run.
   assert {
     condition     = var.create_service_gateway == true
     error_message = "create_service_gateway must be true for service routes to be added to route tables"
+  }
+}
+
+run "sgw_in_public_rt" {
+  command = plan
+
+  variables {
+    create_internet_gateway          = true
+    create_service_gateway           = true
+    add_service_gateway_to_public_rt = true
+  }
+
+  assert {
+    condition     = length(oci_core_route_table.public) == 1
+    error_message = "Public route table should be created when IGW is enabled"
+  }
+
+  # Verify the opt-in flag is set (which drives the dynamic route_rules block on
+  # the public RT). A length() check on route_rules cannot be used at plan time
+  # because the network_entity_id values are computed and unknown until apply.
+  assert {
+    condition     = var.add_service_gateway_to_public_rt == true
+    error_message = "add_service_gateway_to_public_rt must be true for service routes to be added to the public route table"
   }
 }
 

--- a/oci/vcn/variables.tf
+++ b/oci/vcn/variables.tf
@@ -58,7 +58,13 @@ variable "create_nat_gateway" {
 }
 
 variable "create_service_gateway" {
-  description = "(Optional) Whether to create a Service Gateway. When enabled, a service route is added to the public and/or private route tables."
+  description = "(Optional) Whether to create a Service Gateway. When enabled, a service route is added to the private route table (and optionally the public route table — see add_service_gateway_to_public_rt)."
+  type        = bool
+  default     = false
+}
+
+variable "add_service_gateway_to_public_rt" {
+  description = "(Optional) Whether to add a Service Gateway route to the public route table. Defaults to false because OCI rejects combining an Internet Gateway and an 'All Services' Service Gateway route in the same route table."
   type        = bool
   default     = false
 }


### PR DESCRIPTION
## Description

OCI rejects a route table that combines an Internet Gateway route and a Service Gateway (All Services) route — returns `400-InvalidParameter`. Previously, `create_service_gateway=true` added the SGW route to **both** the public and private route tables unconditionally.

## Changes

- **`oci/vcn/variables.tf`** — adds `add_service_gateway_to_public_rt` (default `false`) to opt in to the SGW route on the public route table; updates `create_service_gateway` description to reflect the new split behavior
- **`oci/vcn/main.tf`** — gates the `dynamic "route_rules"` block in the public route table on `var.create_service_gateway && var.add_service_gateway_to_public_rt`
- **`oci/vcn/README.md`** — auto-generated via terraform-docs to reflect new variable
- **`oci/k3s_cluster/vendor/k3s-ansible`** — submodule bump to latest upstream commit

## Design Decisions

- Default is `false` (safe) — existing callers are not broken; the previously-applied SGW route on the public RT was always invalid and would have failed on apply
- Private route table is unchanged — it still receives the SGW route whenever `create_service_gateway=true`
- No change to outputs or other resources

## Testing

- `tofu fmt` — clean
- `tofu validate` — passes via pre-commit hook
- Verified fix unblocks `tofu apply` for an OKE cluster config using `create_internet_gateway=true` + `create_service_gateway=true`