### PR TITLE
fix: ignore OCI auto-applied Oracle-Tags defined_tags drift

### DIFF
--- a/oci/apm/main.tf
+++ b/oci/apm/main.tf
@@ -5,4 +5,8 @@ resource "oci_apm_apm_domain" "this" {
   is_free_tier   = var.is_free_tier
   defined_tags   = var.apm_defined_tags
   freeform_tags  = var.apm_freeform_tags
+
+  lifecycle {
+    ignore_changes = [defined_tags]
+  }
 }

--- a/oci/autonomous_database/main.tf
+++ b/oci/autonomous_database/main.tf
@@ -13,4 +13,8 @@ resource "oci_database_autonomous_database" "this" {
   display_name                = var.display_name
   defined_tags                = var.autonomous_database_defined_tags
   freeform_tags               = var.autonomous_database_freeform_tags
+
+  lifecycle {
+    ignore_changes = [defined_tags]
+  }
 }

--- a/oci/bastion/main.tf
+++ b/oci/bastion/main.tf
@@ -7,4 +7,8 @@ resource "oci_bastion_bastion" "this" {
   max_session_ttl_in_seconds   = var.max_session_ttl_in_seconds
   defined_tags                 = var.bastion_defined_tags
   freeform_tags                = var.bastion_freeform_tags
+
+  lifecycle {
+    ignore_changes = [defined_tags]
+  }
 }

--- a/oci/block_volume/main.tf
+++ b/oci/block_volume/main.tf
@@ -8,6 +8,10 @@ resource "oci_core_volume" "this" {
 
   defined_tags  = var.volume_defined_tags
   freeform_tags = var.volume_freeform_tags
+
+  lifecycle {
+    ignore_changes = [defined_tags]
+  }
 }
 
 resource "oci_core_volume_backup_policy_assignment" "this" {

--- a/oci/budget/main.tf
+++ b/oci/budget/main.tf
@@ -10,6 +10,10 @@ resource "oci_budget_budget" "this" {
   reset_period                          = var.budget_reset_period
   target_type                           = var.budget_target_type
   targets                               = var.budget_targets
+
+  lifecycle {
+    ignore_changes = [defined_tags]
+  }
 }
 
 resource "oci_budget_alert_rule" "this" {
@@ -25,4 +29,8 @@ resource "oci_budget_alert_rule" "this" {
   threshold      = var.alert_threshold
   threshold_type = var.alert_threshold_type
   type           = var.alert_type
+
+  lifecycle {
+    ignore_changes = [defined_tags]
+  }
 }

--- a/oci/certificates/main.tf
+++ b/oci/certificates/main.tf
@@ -12,6 +12,10 @@ resource "oci_certificates_management_certificate_authority" "this" {
   defined_tags   = var.certificates_defined_tags
   freeform_tags  = var.certificates_freeform_tags
 
+  lifecycle {
+    ignore_changes = [defined_tags]
+  }
+
   certificate_authority_config {
     config_type       = var.ca_config_type
     signing_algorithm = var.ca_signing_algorithm
@@ -33,6 +37,10 @@ resource "oci_certificates_management_certificate" "this" {
   name           = var.certificate_name
   defined_tags   = var.certificates_defined_tags
   freeform_tags  = var.certificates_freeform_tags
+
+  lifecycle {
+    ignore_changes = [defined_tags]
+  }
 
   certificate_config {
     config_type                     = var.certificate_config_type

--- a/oci/compute/main.tf
+++ b/oci/compute/main.tf
@@ -46,4 +46,8 @@ resource "oci_core_instance" "this" {
 
   defined_tags  = var.compute_defined_tags
   freeform_tags = var.compute_freeform_tags
+
+  lifecycle {
+    ignore_changes = [defined_tags]
+  }
 }

--- a/oci/connector_hub/main.tf
+++ b/oci/connector_hub/main.tf
@@ -6,6 +6,10 @@ resource "oci_sch_service_connector" "this" {
   defined_tags   = var.connector_defined_tags
   freeform_tags  = var.connector_freeform_tags
 
+  lifecycle {
+    ignore_changes = [defined_tags]
+  }
+
   source {
     kind = var.source_kind
 

--- a/oci/email_delivery/main.tf
+++ b/oci/email_delivery/main.tf
@@ -3,6 +3,10 @@ resource "oci_email_email_domain" "this" {
   name           = var.email_domain_name
   defined_tags   = var.email_defined_tags
   freeform_tags  = var.email_freeform_tags
+
+  lifecycle {
+    ignore_changes = [defined_tags]
+  }
 }
 
 resource "oci_email_sender" "this" {
@@ -10,6 +14,10 @@ resource "oci_email_sender" "this" {
   email_address  = var.sender_email_address
   defined_tags   = var.email_defined_tags
   freeform_tags  = var.email_freeform_tags
+
+  lifecycle {
+    ignore_changes = [defined_tags]
+  }
 }
 
 resource "oci_email_dkim" "this" {
@@ -19,4 +27,8 @@ resource "oci_email_dkim" "this" {
   name            = var.dkim_name
   defined_tags    = var.email_defined_tags
   freeform_tags   = var.email_freeform_tags
+
+  lifecycle {
+    ignore_changes = [defined_tags]
+  }
 }

--- a/oci/identity/main.tf
+++ b/oci/identity/main.tf
@@ -5,4 +5,8 @@ resource "oci_identity_compartment" "this" {
   enable_delete  = var.compartment_enable_delete
   freeform_tags  = var.compartment_freeform_tags
   name           = var.compartment_name
+
+  lifecycle {
+    ignore_changes = [defined_tags]
+  }
 }

--- a/oci/load_balancer/main.tf
+++ b/oci/load_balancer/main.tf
@@ -7,6 +7,10 @@ resource "oci_load_balancer_load_balancer" "this" {
   defined_tags   = var.lb_defined_tags
   freeform_tags  = var.lb_freeform_tags
 
+  lifecycle {
+    ignore_changes = [defined_tags]
+  }
+
   shape_details {
     minimum_bandwidth_in_mbps = 10
     maximum_bandwidth_in_mbps = 10

--- a/oci/logging/main.tf
+++ b/oci/logging/main.tf
@@ -3,6 +3,10 @@ resource "oci_logging_log_group" "this" {
   display_name   = var.log_group_display_name
   defined_tags   = var.logging_defined_tags
   freeform_tags  = var.logging_freeform_tags
+
+  lifecycle {
+    ignore_changes = [defined_tags]
+  }
 }
 
 resource "oci_logging_log" "this" {
@@ -15,6 +19,10 @@ resource "oci_logging_log" "this" {
   retention_duration = each.value.retention_duration
   defined_tags       = var.logging_defined_tags
   freeform_tags      = var.logging_freeform_tags
+
+  lifecycle {
+    ignore_changes = [defined_tags]
+  }
 
   dynamic "configuration" {
     for_each = each.value.log_type == "SERVICE" ? [1] : []

--- a/oci/monitoring/main.tf
+++ b/oci/monitoring/main.tf
@@ -10,4 +10,8 @@ resource "oci_monitoring_alarm" "this" {
   body                  = var.alarm_body
   defined_tags          = var.alarm_defined_tags
   freeform_tags         = var.alarm_freeform_tags
+
+  lifecycle {
+    ignore_changes = [defined_tags]
+  }
 }

--- a/oci/mysql/main.tf
+++ b/oci/mysql/main.tf
@@ -16,6 +16,10 @@ resource "oci_mysql_mysql_db_system" "this" {
   defined_tags        = var.mysql_defined_tags
   freeform_tags       = var.mysql_freeform_tags
 
+  lifecycle {
+    ignore_changes = [defined_tags]
+  }
+
   data_storage_size_in_gb = var.data_storage_size_in_gb
 
   backup_policy {

--- a/oci/network_load_balancer/main.tf
+++ b/oci/network_load_balancer/main.tf
@@ -9,6 +9,10 @@ resource "oci_network_load_balancer_network_load_balancer" "this" {
   is_private     = var.is_private
   defined_tags   = var.nlb_defined_tags
   freeform_tags  = var.nlb_freeform_tags
+
+  lifecycle {
+    ignore_changes = [defined_tags]
+  }
 }
 
 resource "oci_network_load_balancer_backend_set" "this" {

--- a/oci/network_security_group/main.tf
+++ b/oci/network_security_group/main.tf
@@ -4,6 +4,10 @@ resource "oci_core_network_security_group" "this" {
   display_name   = var.nsg_display_name
   defined_tags   = var.nsg_defined_tags
   freeform_tags  = var.nsg_freeform_tags
+
+  lifecycle {
+    ignore_changes = [defined_tags]
+  }
 }
 
 resource "oci_core_network_security_group_security_rule" "this" {

--- a/oci/nosql/main.tf
+++ b/oci/nosql/main.tf
@@ -5,6 +5,10 @@ resource "oci_nosql_table" "this" {
   defined_tags   = var.nosql_defined_tags
   freeform_tags  = var.nosql_freeform_tags
 
+  lifecycle {
+    ignore_changes = [defined_tags]
+  }
+
   table_limits {
     max_read_units     = var.table_limits_max_read_units
     max_write_units    = var.table_limits_max_write_units

--- a/oci/notifications/main.tf
+++ b/oci/notifications/main.tf
@@ -4,6 +4,10 @@ resource "oci_ons_notification_topic" "this" {
   description    = var.topic_description
   defined_tags   = var.notifications_defined_tags
   freeform_tags  = var.notifications_freeform_tags
+
+  lifecycle {
+    ignore_changes = [defined_tags]
+  }
 }
 
 resource "oci_ons_subscription" "this" {

--- a/oci/object_storage/main.tf
+++ b/oci/object_storage/main.tf
@@ -18,4 +18,8 @@ resource "oci_objectstorage_bucket" "this" {
   kms_key_id            = var.kms_key_id
   defined_tags          = var.bucket_defined_tags
   freeform_tags         = var.bucket_freeform_tags
+
+  lifecycle {
+    ignore_changes = [defined_tags]
+  }
 }

--- a/oci/oke_cluster/main.tf
+++ b/oci/oke_cluster/main.tf
@@ -7,6 +7,10 @@ resource "oci_containerengine_cluster" "this" {
   defined_tags       = var.cluster_defined_tags
   freeform_tags      = var.cluster_freeform_tags
 
+  lifecycle {
+    ignore_changes = [defined_tags]
+  }
+
   endpoint_config {
     subnet_id            = var.endpoint_subnet_id
     is_public_ip_enabled = var.endpoint_is_public_ip_enabled

--- a/oci/oke_node_pool/main.tf
+++ b/oci/oke_node_pool/main.tf
@@ -11,6 +11,10 @@ resource "oci_containerengine_node_pool" "this" {
   freeform_tags      = var.node_pool_freeform_tags
   ssh_public_key     = var.ssh_public_key
 
+  lifecycle {
+    ignore_changes = [defined_tags]
+  }
+
   node_shape = var.node_shape
 
   dynamic "node_shape_config" {

--- a/oci/security_list/main.tf
+++ b/oci/security_list/main.tf
@@ -5,6 +5,10 @@ resource "oci_core_security_list" "this" {
   defined_tags   = var.security_list_defined_tags
   freeform_tags  = var.security_list_freeform_tags
 
+  lifecycle {
+    ignore_changes = [defined_tags]
+  }
+
   dynamic "ingress_security_rules" {
     for_each = var.ingress_security_rules
     content {

--- a/oci/subnet/main.tf
+++ b/oci/subnet/main.tf
@@ -11,4 +11,8 @@ resource "oci_core_subnet" "this" {
 
   defined_tags  = var.subnet_defined_tags
   freeform_tags = var.subnet_freeform_tags
+
+  lifecycle {
+    ignore_changes = [defined_tags]
+  }
 }

--- a/oci/vault/main.tf
+++ b/oci/vault/main.tf
@@ -4,6 +4,10 @@ resource "oci_kms_vault" "this" {
   vault_type     = var.vault_type
   defined_tags   = var.vault_defined_tags
   freeform_tags  = var.vault_freeform_tags
+
+  lifecycle {
+    ignore_changes = [defined_tags]
+  }
 }
 
 resource "oci_kms_key" "this" {
@@ -14,6 +18,10 @@ resource "oci_kms_key" "this" {
   management_endpoint = oci_kms_vault.this.management_endpoint
   defined_tags        = var.vault_defined_tags
   freeform_tags       = var.vault_freeform_tags
+
+  lifecycle {
+    ignore_changes = [defined_tags]
+  }
 
   key_shape {
     algorithm = var.key_algorithm

--- a/oci/vcn/main.tf
+++ b/oci/vcn/main.tf
@@ -15,6 +15,10 @@ resource "oci_core_vcn" "this" {
 
   defined_tags  = var.vcn_defined_tags
   freeform_tags = var.vcn_freeform_tags
+
+  lifecycle {
+    ignore_changes = [defined_tags]
+  }
 }
 
 resource "oci_core_internet_gateway" "this" {
@@ -26,6 +30,10 @@ resource "oci_core_internet_gateway" "this" {
   display_name   = "${var.vcn_display_name}-igw"
   enabled        = true
   freeform_tags  = var.vcn_freeform_tags
+
+  lifecycle {
+    ignore_changes = [defined_tags]
+  }
 }
 
 resource "oci_core_nat_gateway" "this" {
@@ -36,6 +44,10 @@ resource "oci_core_nat_gateway" "this" {
   defined_tags   = var.vcn_defined_tags
   display_name   = "${var.vcn_display_name}-natgw"
   freeform_tags  = var.vcn_freeform_tags
+
+  lifecycle {
+    ignore_changes = [defined_tags]
+  }
 }
 
 resource "oci_core_service_gateway" "this" {
@@ -52,6 +64,7 @@ resource "oci_core_service_gateway" "this" {
   }
 
   lifecycle {
+    ignore_changes = [defined_tags]
     precondition {
       condition     = local.service != null
       error_message = "No OCI service matching 'All .* Services In Oracle Services Network' was found in this region. Cannot create service gateway."
@@ -84,6 +97,7 @@ resource "oci_core_route_table" "public" {
   }
 
   lifecycle {
+    ignore_changes = [defined_tags]
     precondition {
       condition     = !var.add_service_gateway_to_public_rt || var.create_service_gateway
       error_message = "add_service_gateway_to_public_rt requires create_service_gateway = true."
@@ -99,6 +113,10 @@ resource "oci_core_route_table" "private" {
   defined_tags   = var.vcn_defined_tags
   display_name   = "${var.vcn_display_name}-private-rt"
   freeform_tags  = var.vcn_freeform_tags
+
+  lifecycle {
+    ignore_changes = [defined_tags]
+  }
 
   route_rules {
     destination       = "0.0.0.0/0"
@@ -131,4 +149,8 @@ resource "oci_core_security_list" "this" {
   defined_tags   = var.vcn_defined_tags
   display_name   = "${var.vcn_display_name}-security-list"
   freeform_tags  = var.vcn_freeform_tags
+
+  lifecycle {
+    ignore_changes = [defined_tags]
+  }
 }

--- a/oci/vpn/main.tf
+++ b/oci/vpn/main.tf
@@ -3,6 +3,10 @@ resource "oci_core_drg" "this" {
   display_name   = var.drg_display_name
   defined_tags   = var.vpn_defined_tags
   freeform_tags  = var.vpn_freeform_tags
+
+  lifecycle {
+    ignore_changes = [defined_tags]
+  }
 }
 
 resource "oci_core_drg_attachment" "this" {
@@ -23,6 +27,10 @@ resource "oci_core_cpe" "this" {
   display_name   = var.cpe_display_name
   defined_tags   = var.vpn_defined_tags
   freeform_tags  = var.vpn_freeform_tags
+
+  lifecycle {
+    ignore_changes = [defined_tags]
+  }
 }
 
 resource "oci_core_ipsec" "this" {
@@ -33,4 +41,8 @@ resource "oci_core_ipsec" "this" {
   static_routes  = var.static_routes
   defined_tags   = var.vpn_defined_tags
   freeform_tags  = var.vpn_freeform_tags
+
+  lifecycle {
+    ignore_changes = [defined_tags]
+  }
 }


### PR DESCRIPTION
## Description

OCI automatically injects `Oracle-Tags.CreatedBy` and `Oracle-Tags.CreatedOn` into every resource's `defined_tags` at creation time. Without `ignore_changes`, every subsequent `plan` shows spurious in-place updates attempting to remove these tags.

## Changes

- Add `lifecycle { ignore_changes = [defined_tags] }` to all resources across all 26 modules that accept `defined_tags`
- For resources with existing `lifecycle` blocks (vcn module), `ignore_changes` is added inside the existing block alongside existing `precondition` blocks

## Design Decisions

- Only resources with `defined_tags` in their schema are affected — resources that don't accept `defined_tags` (e.g., `oci_core_volume_backup_policy_assignment`, `oci_load_balancer_backend`, `oci_nosql_index`) are left unchanged
- `freeform_tags` is intentionally NOT ignored — those are fully user-managed and should remain under Terraform control

## Testing

- `pre-commit run --all-files` passes (terraform fmt, tflint, terraform-docs, validate)